### PR TITLE
gradle-cicd: add image versioning

### DIFF
--- a/.github/workflows/gradle-cicd.yaml
+++ b/.github/workflows/gradle-cicd.yaml
@@ -74,9 +74,12 @@ jobs:
       TOKEN: ${{ needs.Prepare.outputs.token }}
     steps:
       - uses: actions/checkout@v3
+      - name: Set env
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF#refs/*/} | sed 's/[^0-9^\.]*//g')" >> $GITHUB_ENV
       - uses: go-picky/picky-cicd/actions/gradle/build-and-release@main
         with:
           name: ${{ inputs.name }}
+          version: ${{ env.RELEASE_VERSION }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   Deploy:

--- a/actions/docker/build-and-push/action.yaml
+++ b/actions/docker/build-and-push/action.yaml
@@ -10,6 +10,7 @@ inputs:
     required: false
     description: 'Version used to tag the docker image'
     type: string
+    default: latest
   aws_access_key_id:
     required: true
     description: 'AWS access key ID'
@@ -37,7 +38,7 @@ runs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ inputs.name }}-test # remove '-test' once confirmed working
-        IMAGE_TAG: latest
+        IMAGE_TAG: ${{ inputs.version }}
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/actions/gradle/build-and-release/action.yaml
+++ b/actions/gradle/build-and-release/action.yaml
@@ -6,6 +6,10 @@ inputs:
     required: true
     description: 'Name of the project which will be used name the docker image'
     type: string
+  version:
+    required: false
+    description: 'Version of the project which will be used tag the docker image'
+    type: string
   aws_access_key_id:
     required: true
     description: 'AWS access key ID'
@@ -31,5 +35,6 @@ runs:
       uses: go-picky/picky-cicd/actions/docker/build-and-push@main
       with:
         name: ${{ inputs.name }}
+        version: ${{ inputs.version }}
         aws_access_key_id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Any commits will tag the docker image with 'latest' and commits triggered using github tags will tag the docker image with the version e.g. v0.0.3 -> image:0.0.3