### PR TITLE
disable interactive apply

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -17,6 +17,10 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
+      DEV_CONFIG_FILE:
+        required: true
+      PRD_CONFIG_FILE:
+        required: true
 
 jobs:
   dev-deploy:
@@ -27,6 +31,10 @@ jobs:
     if: ${{ inputs.job == 'dev-deploy'}}
     steps:
       - uses: actions/checkout@v3
+      - uses: go-picky/picky-cicd/actions/terraform/setup-config@task/add-terraform-workflow
+        with:
+          dev_config_file: ${{ secrets.DEV_CONFIG_FILE }}
+          prd_config_file: ${{ secrets.PRD_CONFIG_FILE }}
       - run: terraform init
       - run: |
           terraform apply \
@@ -41,6 +49,10 @@ jobs:
     if: ${{ inputs.job == 'prod-deploy'}}
     steps:
       - uses: actions/checkout@v3
+      - uses: go-picky/picky-cicd/actions/terraform/setup-config@task/add-terraform-workflow
+        with:
+          dev_config_file: ${{ secrets.DEV_CONFIG_FILE }}
+          prd_config_file: ${{ secrets.PRD_CONFIG_FILE }}
       - run: terraform init
       - run: |
           terraform apply \

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -36,6 +36,14 @@ jobs:
           dev_config_file: ${{ secrets.DEV_CONFIG_FILE }}
           prd_config_file: ${{ secrets.PRD_CONFIG_FILE }}
       - run: terraform init
+      # TODO: add auto-approve once confirmed
+      # - run: |
+      #     terraform apply -auto-approve \
+      #       -var-file environments/development.tfvars \
+      #       -var 'AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY_ID }}' \
+      #       -var 'AWS_SECRET_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+
+      # TODO: remove interactive apply once confirmed
       - run: |
           terraform apply \
             -var-file environments/development.tfvars \

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -39,8 +39,8 @@ jobs:
       - run: |
           terraform apply \
             -var-file environments/development.tfvars \
-            -var 'AWS_ACCESS_KEY=${{ inputs.aws_access_key_id }}' \
-            -var 'AWS_SECRET_KEY=${{ inputs.aws_secret_access_key }}'
+            -var 'AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY_ID }}' \
+            -var 'AWS_SECRET_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}'
   prod-deploy:
     environment: production
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -1,0 +1,49 @@
+---
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      version:
+        required: false
+        type: string
+      job:
+        description: 'Job to run'
+        required: true
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+jobs:
+  dev-deploy:
+    environment: development
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:latest@sha256:bab3667a19fb157750505765468dba6e1f4c06007cbb503c4e2a8ab0a02b813c
+    if: ${{ inputs.job == 'dev-deploy'}}
+    steps:
+      - uses: actions/checkout@v3
+      - run: terraform init
+      - run: |
+          terraform apply \
+            -var-file environments/development.tfvars \
+            -var 'AWS_ACCESS_KEY=${{ inputs.aws_access_key_id }}' \
+            -var 'AWS_SECRET_KEY=${{ inputs.aws_secret_access_key }}'
+  prod-deploy:
+    environment: production
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:latest@sha256:bab3667a19fb157750505765468dba6e1f4c06007cbb503c4e2a8ab0a02b813c
+    if: ${{ inputs.job == 'prod-deploy'}}
+    steps:
+      - uses: actions/checkout@v3
+      - run: terraform init
+      - run: |
+          terraform apply \
+            -var-file environments/production.tfvars \
+            -var 'AWS_ACCESS_KEY=${{ inputs.aws_access_key_id }}' \
+            -var 'AWS_SECRET_KEY=${{ inputs.aws_secret_access_key }}'

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -36,16 +36,8 @@ jobs:
           dev_config_file: ${{ secrets.DEV_CONFIG_FILE }}
           prd_config_file: ${{ secrets.PRD_CONFIG_FILE }}
       - run: terraform init
-      # TODO: add auto-approve once confirmed
-      # - run: |
-      #     terraform apply -auto-approve \
-      #       -var-file environments/development.tfvars \
-      #       -var 'AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY_ID }}' \
-      #       -var 'AWS_SECRET_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-
-      # TODO: remove interactive apply once confirmed
       - run: |
-          terraform apply \
+          terraform apply -auto-approve \
             -var-file environments/development.tfvars \
             -var 'AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY_ID }}' \
             -var 'AWS_SECRET_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}'

--- a/.github/workflows/terraform-validate-and-release.yaml
+++ b/.github/workflows/terraform-validate-and-release.yaml
@@ -1,0 +1,22 @@
+---
+on:
+  workflow_call:
+
+jobs:
+  Prepare:
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Prepare - placeholder
+  Validate:
+    environment: development
+    needs: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: go-picky/picky-cicd/actions/terraform/validate@task/add-terraform-workflow
+  Scan:
+    environment: development
+    needs: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: go-picky/picky-cicd/actions/terraform/scan@task/add-terraform-workflow

--- a/actions/terraform/build/action.yaml
+++ b/actions/terraform/build/action.yaml
@@ -1,0 +1,33 @@
+---
+name: 'Terraform Plan'
+description: 'Generate terraform plan files'
+
+inputs:
+  aws_access_key_id:
+    required: true
+    description: 'AWS access key ID'
+    type: string
+  aws_secret_access_key:
+    required: true
+    description: 'AWS secret access key'
+    type: string
+  environment:
+    required: true
+    description: 'environment name'
+    type: string
+    default: development
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - run: env
+      shell: bash
+    - run: terraform init
+      shell: bash
+    - run: |
+        terraform plan \
+          -var-file environments/${{ inputs.environment }}.tfvars \
+          -var 'AWS_ACCESS_KEY=${{ inputs.aws_access_key_id }}' \
+          -var 'AWS_SECRET_KEY=${{ inputs.aws_secret_access_key }}'
+      shell: bash

--- a/actions/terraform/scan/action.yaml
+++ b/actions/terraform/scan/action.yaml
@@ -1,0 +1,26 @@
+---
+name: 'Terraform Scan'
+description: 'Run static code analysis on the project'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - name: Run Checkov action
+      id: checkov
+      uses: bridgecrewio/checkov-action@master
+      with:
+        quiet: true
+        framework: terraform
+        soft_fail: true
+        output_format: junitxml
+        download_external_modules: true
+        log_level: DEBUG
+    - run: echo $CHECKOV_RESULTS > report.xml
+      shell: bash
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      with:
+        name: Scanning Report
+        path: report.xml
+        reporter: java-junit

--- a/actions/terraform/setup-config/action.yaml
+++ b/actions/terraform/setup-config/action.yaml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: echo ${{ inputs.dev_config_file }} > environments/development.tfvars
+    - run: echo "${{ inputs.dev_config_file }}" > environments/development.tfvars
       shell: sh
-    - run: echo ${{ inputs.prd_config_file }} > environments/production.tfvars
+    - run: echo "${{ inputs.prd_config_file }}" > environments/production.tfvars
       shell: sh

--- a/actions/terraform/setup-config/action.yaml
+++ b/actions/terraform/setup-config/action.yaml
@@ -15,6 +15,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - run: mkdir environments
+      shell: sh
     - run: echo "${{ inputs.dev_config_file }}" > environments/development.tfvars
       shell: sh
     - run: echo "${{ inputs.prd_config_file }}" > environments/production.tfvars

--- a/actions/terraform/setup-config/action.yaml
+++ b/actions/terraform/setup-config/action.yaml
@@ -17,7 +17,8 @@ runs:
   steps:
     - run: mkdir environments
       shell: sh
-    - run: echo "${{ inputs.dev_config_file }}" > environments/development.tfvars
+    # TODO: fix single quote escaping in config files
+    - run: echo '${{ inputs.dev_config_file }}' > environments/development.tfvars
       shell: sh
-    - run: echo "${{ inputs.prd_config_file }}" > environments/production.tfvars
+    - run: echo '${{ inputs.prd_config_file }}' > environments/production.tfvars
       shell: sh

--- a/actions/terraform/setup-config/action.yaml
+++ b/actions/terraform/setup-config/action.yaml
@@ -16,6 +16,6 @@ runs:
   using: 'composite'
   steps:
     - run: echo ${{ inputs.dev_config_file }} > environments/development.tfvars
-      shell: bash
+      shell: sh
     - run: echo ${{ inputs.prd_config_file }} > environments/production.tfvars
-      shell: bash
+      shell: sh

--- a/actions/terraform/setup-config/action.yaml
+++ b/actions/terraform/setup-config/action.yaml
@@ -1,0 +1,21 @@
+---
+name: 'Terraform Setup Config'
+description: 'Setup Config'
+
+inputs:
+  dev_config_file:
+    required: true
+    description: 'config file'
+    type: string
+  prd_config_file:
+    required: true
+    description: 'config file'
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - run: echo ${{ inputs.dev_config_file }} > environments/development.tfvars
+      shell: bash
+    - run: echo ${{ inputs.prd_config_file }} > environments/production.tfvars
+      shell: bash

--- a/actions/terraform/validate/action.yaml
+++ b/actions/terraform/validate/action.yaml
@@ -1,0 +1,10 @@
+---
+name: 'Terraform Validate'
+description: 'Run validation on project'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+    - name: terraform validate
+      uses: dflook/terraform-validate@v1


### PR DESCRIPTION
@amoallim15 need to understand how we are currently managing states in terraform. The current terraform pipeline does not manage the states so will most likely error or spin up a new set of infra when `terraform apply` is run.